### PR TITLE
Developer Mode checkbox mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ simple chrome extension to force the mixpanel object into debug mode
 to install:
 
 1. Download the code
-2. Open chrome preferences, click "Extensions" in the menu, then "Load unpacked extension..."
-3. Select the repo folder
-4. Check "Allow in incognito"
+2. Open chrome preferences, click "Extensions" in the menu
+3. Ensure that the Developer Mode checkbox in the top right-hand corner is checked, then "Load unpacked extension..."
+4. Select the repo folder
+5. Check "Allow in incognito"


### PR DESCRIPTION
When the Developer Mode checkbox is unchecked, the 'Load unpacked extension' button isn't available.
